### PR TITLE
feat: Adding chain labels to metrics for tracking individual chains

### DIFF
--- a/health.js
+++ b/health.js
@@ -26,9 +26,21 @@ let healthStatuses = {};
 // Prometheus metrics
 // Create a Registry which registers the metrics
 const register = new Prometheus.Registry()
-const deltaMetric = new Prometheus.Gauge({ name: 'block_number_delta', help: 'Block number delta between Infura and The Graph' });
-const responseTimeMetric = new Prometheus.Gauge({ name: 'response_time', help: 'Response time in milliseconds' });
-const errorRateMetric = new Prometheus.Gauge({ name: 'error_rate', help: 'Average error rate for the past Y queries' });
+const deltaMetric = new Prometheus.Gauge({
+    name: 'block_number_delta',
+    help: 'Block number delta between Infura and The Graph',
+    labelNames: ['chain'],
+});
+const responseTimeMetric = new Prometheus.Gauge({
+    name: 'response_time',
+    help: 'Response time in milliseconds',
+    labelNames: ['chain'],
+});
+const errorRateMetric = new Prometheus.Gauge({
+    name: 'error_rate',
+    help: 'Average error rate for the past Y queries',
+    labelNames: ['chain'],
+});
 
 register.registerMetric(deltaMetric);
 register.registerMetric(responseTimeMetric);
@@ -79,8 +91,8 @@ const checkHealth = async (config, errorRates) => {
             errorRates.shift();
         }
 
-        deltaMetric.set(delta);
-        responseTimeMetric.set(responseTime);
+        deltaMetric.labels(config.name).set(delta);
+        responseTimeMetric.labels(config.name).set(responseTime);
 
     } catch (error) {
         console.error(`[${config.name}]`, error);
@@ -88,8 +100,8 @@ const checkHealth = async (config, errorRates) => {
         if (errorRates.length > config.Y) {
             errorRates.shift();
         }
-        deltaMetric.set(-1);
-        responseTimeMetric.set(-1);
+        deltaMetric.labels(config.name).set(-1);
+        responseTimeMetric.labels(config.name).set(-1);
 
     } finally {
         const averageErrorRate = calculateAverageErrorRate(errorRates);
@@ -100,7 +112,7 @@ const checkHealth = async (config, errorRates) => {
         } else {
             healthStatus = "healthy";
         }
-        errorRateMetric.set(averageErrorRate * 100);
+        errorRateMetric.labels(config.name).set(averageErrorRate * 100);
     }
     return healthStatus;
 };


### PR DESCRIPTION
I like triggering alerts from Grafana, so I needed a bit more granularity in the metrics. I accomplished this by adding labels names to the new prometheus guage, and chain name labels when setting a metric. Feel free to merge if you'd like the updated metrics as well.

Before:
```
# HELP block_number_delta Block number delta between Infura and The Graph
# TYPE block_number_delta gauge
block_number_delta 6

# HELP response_time Response time in milliseconds
# TYPE response_time gauge
response_time 52

# HELP error_rate Average error rate for the past Y queries
# TYPE error_rate gauge
error_rate 0
```
After:
```
# HELP block_number_delta Block number delta between Infura and The Graph
# TYPE block_number_delta gauge
block_number_delta{chain="mainnet"} 0
block_number_delta{chain="arbitrum-one"} 4
block_number_delta{chain="base"} 1
block_number_delta{chain="matic"} 43310
block_number_delta{chain="scroll"} 1
block_number_delta{chain="optimism"} 1
block_number_delta{chain="celo"} 1
block_number_delta{chain="gnosis"} 0
block_number_delta{chain="blast-mainnet"} 1
block_number_delta{chain="avalanche"} 0
block_number_delta{chain="fantom"} 2

# HELP response_time Response time in milliseconds
# TYPE response_time gauge
response_time{chain="mainnet"} 30
response_time{chain="arbitrum-one"} 36
response_time{chain="base"} 25
response_time{chain="matic"} 38
response_time{chain="scroll"} 25
response_time{chain="optimism"} 32
response_time{chain="celo"} 49
response_time{chain="gnosis"} 30
response_time{chain="blast-mainnet"} 24
response_time{chain="avalanche"} 23
response_time{chain="fantom"} 23

# HELP error_rate Average error rate for the past Y queries
# TYPE error_rate gauge
error_rate{chain="mainnet"} 0
error_rate{chain="arbitrum-one"} 0
error_rate{chain="base"} 0
error_rate{chain="matic"} 100
error_rate{chain="scroll"} 0
error_rate{chain="optimism"} 0
error_rate{chain="celo"} 0
error_rate{chain="gnosis"} 0
error_rate{chain="blast-mainnet"} 0
error_rate{chain="avalanche"} 0
error_rate{chain="fantom"} 0
```