### PR TITLE
Fix for when infura is behind chainhead

### DIFF
--- a/health.js
+++ b/health.js
@@ -78,7 +78,8 @@ const checkHealth = async (config, errorRates) => {
             params: []
         });
         const infuraBlockNumber = parseInt(infuraBlockNumberResponse.result,16);
-        const delta = Math.abs(parseInt(subgraphBlockNumber) - infuraBlockNumber);
+        const trueDelta = parseInt(subgraphBlockNumber) - infuraBlockNumber;
+        const delta = trueDelta <= 0 ? Math.abs(trueDelta) : 0;
 
         console.log(`[${config.name}] Subgraph block number: ${subgraphBlockNumber}, Infura block number: ${infuraBlockNumber}, Delta: ${delta}, Response time: ${responseTime}ms`);
 


### PR DESCRIPTION
I got a notification that optimism was falling behind chainhead yesterday, but I couldn't figure out why as everything that I was looking at said we were healthy. Then, I looked at the indexer-health logs and noticed it was actually alchemy that was behind chainhead, but it was being reported the same because of `Math.abs()` on the difference between remote and local. This check that local is smaller than remote (`trueDelta <= 0`) and setting delta as 0 otherwise takes care of that case, confirmed with our own deployment.